### PR TITLE
fix(page-transition-loader): don't trigger when href === pathname

### DIFF
--- a/src/components/CustomLink.tsx
+++ b/src/components/CustomLink.tsx
@@ -28,6 +28,7 @@ function CustomLink({
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
+    if (pathname === href) return
     setIsTransitioning(true)
     startTransition(() => {
       router.push(href)


### PR DESCRIPTION
This is to avoid the indicator being triggered when clicking on a link to the current page. In which case it would the loader wouldn't switch off.